### PR TITLE
Add Friends dialogue parser

### DIFF
--- a/utils/friends_dialogue_parse.py
+++ b/utils/friends_dialogue_parse.py
@@ -1,0 +1,84 @@
+# Parses dialogue from the show Friends provided by the Character Mining project
+# https://github.com/emorynlp/character-mining
+# The tsv file can be downloaded with
+# wget https://raw.githubusercontent.com/gmihaila/character-mining/developer/tsv/friends_transcripts.tsv
+import argparse
+import csv
+import re
+import tqdm
+
+from clean import clean
+
+
+class InvalidFormatError(Exception):
+    pass
+
+
+class InvalidUtteranceError(Exception):
+    pass
+
+
+def valid_csv(dict_reader):
+    return (dict_reader.fieldnames is not None and
+            set(dict_reader.fieldnames) == {'season_id', 'episode_id', 'scene_id', 'utterance_id', 'speaker', 'tokens', 'transcript'})
+
+
+def format_conversation_metadata(utterance):
+    return f'[Season: {utterance["season_id"]}; Episode: {utterance["episode_id"]}; Conversation: {utterance["scene_id"]};]'
+
+
+def format_utterance(utterance):
+    speaker = utterance['speaker']
+    # there are some invalid lines with the speaker "unknown"
+    if speaker == 'unknown':
+        raise InvalidUtteranceError()
+    # remove parenthetical description of characters
+    speaker = re.sub(r'\(.*\)', '', speaker)
+    speaker = speaker.strip()
+
+    line = clean(utterance['transcript'])
+    # there are some invalid empty lines
+    if line == '':
+        raise InvalidUtteranceError()
+
+    return f'{speaker}: {line}'
+
+
+def different_conversations(utterance1, utterance2):
+    return (utterance1['season_id'] != utterance2['season_id'] or
+            utterance1['episode_id'] != utterance2['episode_id'] or
+            utterance1['scene_id'] != utterance2['scene_id'])
+
+
+def parse_dialogue(in_filename, out_filename):
+    with open(in_filename, 'r', encoding='utf-8') as in_file, open(out_filename, 'w', encoding='utf-8') as out_file:
+        reader = csv.DictReader(in_file, delimiter='\t')
+        if not valid_csv(reader):
+            raise InvalidFormatError(f'{in_filename} is not formatted correctly')
+        last_utterance = None
+        for utterance in tqdm.tqdm(reader):
+            if last_utterance is None or different_conversations(last_utterance, utterance):
+                out_file.write(f'⁂\n{format_conversation_metadata(utterance)}\n⁂\n')
+            try:
+                out_file.write(f'{format_utterance(utterance)}\n')
+            except InvalidUtteranceError:
+                pass
+            last_utterance = utterance
+
+
+parser = argparse.ArgumentParser(description='Process Friends dialogue\n\n'
+                                             'The data is taken from\n'
+                                             'https://github.com/emorynlp/character-mining\n\n'
+                                             'It can be downloaded with\n'
+                                             'wget https://raw.githubusercontent.com/emorynlp/character-mining/master/tsv/friends_transcripts.tsv',
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('file', type=str, help='tsv file to process')
+parser.add_argument('-o', '--out', type=str, help='file to output', default='friends_dialogue.txt')
+args = parser.parse_args()
+
+if __name__ == '__main__':
+    try:
+        parse_dialogue(args.file, args.out)
+    except (FileNotFoundError, InvalidFormatError) as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
This script parses the tsv file containing the dialogue of every episode of Friends provided by the Character Mining project. The project is located here
https://github.com/emorynlp/character-mining

The direct link to the tsv is
https://raw.githubusercontent.com/emorynlp/character-mining/master/tsv/friends_transcripts.tsv

The result looks like
```
⁂
[Season: s01; Episode: e01; Conversation: c01;]
⁂
Monica Geller: There's nothing to tell! He's just some guy I work with!
Joey Tribbiani: C'mon, you're going out with the guy! There's gotta be something wrong with him!
Chandler Bing: All right Joey, be nice. So does he have a hump? A hump and a hairpiece?
Phoebe Buffay: Wait, does he eat chalk?
Phoebe Buffay: Just, 'cause, I don't want her to go through what I went through with Carl- oh!
Monica Geller: Okay, everybody relax. This is not even a date. It's just two people going out to dinner and- not having sex.
Chandler Bing: Sounds like a date to me.
```

I made two changes to clean up the data. I removed character descriptions, such as `Katie (saleswoman)` from the names of the characters. I also removed lines that were tagged with the character `unknown` or were blank. When I checked the original transcript, it seemed that those lines originally contained action notes.

A very small number of the lines still contain action notes, but I decided to leave them in because real chats might include those kinds of notes. Finally, lines where everyone spoke were tagged with `#ALL#`. I decided to leave it in this form since this isn't a proper character.